### PR TITLE
Dilation slider added to the config for export to Photoshop

### DIFF
--- a/ConfigurePanel.qml
+++ b/ConfigurePanel.qml
@@ -10,9 +10,9 @@ AlgDialog {
   visible: false
   title: qsTr("Configure")
   width: 500
-  height: 220
+  height: 240
   minimumWidth: 400
-  minimumHeight: 220
+  minimumHeight: 240
 
   function reload() {
     content.reload()
@@ -26,6 +26,7 @@ AlgDialog {
 		alg.settings.setValue("padding", paddingCheckBox.checked);
         var index = bitDepthComboBox.currentIndex
         alg.settings.setValue("bitDepth", bitDepthModel.get(index).value);
+    alg.settings.setValue("dilation", dilationSlider.value);
   }
 
   Rectangle {
@@ -41,6 +42,7 @@ AlgDialog {
       launchPhotoshopCheckBox.reload()
       paddingCheckBox.reload()
       bitDepthComboBox.reload()
+      dilationSlider.reload()
     }
 
     AlgScrollView {
@@ -129,6 +131,36 @@ AlgDialog {
             reload()
           }
         }
+      }
+
+      RowLayout {
+          spacing: 6
+
+          AlgLabel {
+          text: qsTr("Dilation")
+          Layout.fillWidth: true
+        }
+
+        AlgSlider {
+          id: dilationSlider
+
+          minValue: 0
+          maxValue: 256
+          stepSize: 2
+          Layout.fillWidth: true
+
+          enabled: !paddingCheckBox.checked
+
+          function reload() {
+            value = alg.settings.value("dilation", 0);
+          }
+
+          Component.onCompleted: {
+            reload()
+          }
+        }
+
+        
       }
 
       RowLayout {

--- a/photoshop.js
+++ b/photoshop.js
@@ -45,6 +45,10 @@ function PhotoshopExporter(callback) {
   this.exportConfig = new ExportConfig()
   this.exportConfig.usePadding(alg.settings.value("padding", false))
 
+  // Set Dilation
+  // Added by CPAWLIUK to allow users to send to Photoshop with dilation
+  this.exportConfig.dilation = alg.settings.value("dilation", 0);
+
   //Get the project name
   var projectName = alg.project.name()
 


### PR DESCRIPTION
Added a dilation slider to the config that will allow the user to export to Photoshop with that value if they're not using Padding (Infinite) already.

This was added on the request of a user in the Discord.

Thanks!
(Chris) CAGameDev <- My discord name in the Substance Discord