### PR TITLE
Update photoshop.js to fix color space

### DIFF
--- a/photoshop.js
+++ b/photoshop.js
@@ -184,8 +184,18 @@ PhotoshopExporter.prototype = {
           //Update the progress bar
           this.photoshopScript += "progressBar.layer.value = 0; \n";
           //Gamma correction for sRGB channel
-          if(this.channel == "basecolor" || this.channel == "diffuse" || this.channel == "specular" || this.channel == "emissive" || this.channel == "transmissive" ) {
-            this.photoshopScript += " convert_to_profile(); \n";
+          if(this.channel == "basecolor"
+          || this.channel == "diffuse"
+          || this.channel == "specular"
+          || this.channel == "emissive"
+          || this.channel == "transmissive"
+          || this.channel == "absorptioncolor"
+          || this.channel == "sheencolor"
+          || this.channel == "coatcolor"
+          || this.channel == "coatroughness"
+          || this.channel == "scatteringcolor"
+          || this.channel == "specularedgecolor") {
+            this.photoshopScript += "app.activeDocument.convertProfile( \"Working RGB\", Intent.PERCEPTUAL, false, false ); \n"
           }
           // Add default background in normal channel
           if(this.channel === "normal") {


### PR DESCRIPTION
This change switch the default color space of PSD files for color managed channels to the standard sRGB instead of using the custom sRGB (gamma 1.0) profile defined by the plugin. This change match users expectations and requests. It creates less issues as well when copying the PSD content into other documents.

If users want to blend layers using Gamma 1.0 (as done in Painter), they can do it by changing Photoshop preferences (Edit > Color Settings > Blend RGB Colors Using Gamma 1.0).

This change also take into account channels that have been added in recent versions of Painter and were currently ignored.