### PR TITLE
Remove coatroughness from channel list

### DIFF
--- a/photoshop.js
+++ b/photoshop.js
@@ -192,7 +192,6 @@ PhotoshopExporter.prototype = {
           || this.channel == "absorptioncolor"
           || this.channel == "sheencolor"
           || this.channel == "coatcolor"
-          || this.channel == "coatroughness"
           || this.channel == "scatteringcolor"
           || this.channel == "specularedgecolor") {
             this.photoshopScript += "app.activeDocument.convertProfile( \"Working RGB\", Intent.PERCEPTUAL, false, false ); \n"

--- a/photoshop.js
+++ b/photoshop.js
@@ -184,8 +184,18 @@ PhotoshopExporter.prototype = {
           //Update the progress bar
           this.photoshopScript += "progressBar.layer.value = 0; \n";
           //Gamma correction for sRGB channel
-          if(this.channel == "basecolor" || this.channel == "diffuse" || this.channel == "specular" || this.channel == "emissive" || this.channel == "transmissive" ) {
-            this.photoshopScript += " convert_to_profile(); \n";
+          if(this.channel == "basecolor"
+          || this.channel == "diffuse"
+          || this.channel == "specular"
+          || this.channel == "emissive"
+          || this.channel == "transmissive"
+          || this.channel == "absorptioncolor"
+          || this.channel == "sheencolor"
+          || this.channel == "coatcolor"
+          || this.channel == "coatroughness"
+          || this.channel == "scatteringcolor"
+          || this.channel == "specularedgecolor") {
+            this.photoshopScript += "app.activeDocument.convertProfile( \"Working RGB\", Intent.PERCEPTUAL, false, false ); \n"
           }
           // Add default background in normal channel
           if(this.channel === "normal") {


### PR DESCRIPTION
Removes the "coatroughness" line from the list of channels that should get applied the sRGB color space. This is a data channel, it shouldn't be included.